### PR TITLE
Add option to skip running tests

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -2,7 +2,7 @@
 
 var ploy = require('../');
 var argv = require('optimist')
-    .boolean([ 'q', 'quiet', 'v', 'verbose' ])
+    .boolean([ 'q', 'quiet', 'v', 'verbose', 'skip-test' ])
     .argv
 ;
 var exec = require('child_process').exec;
@@ -210,6 +210,7 @@ else if (true || cmd === 'server') {
         logdir: path.join(dir, 'log'),
         auth: authFile && JSON.parse(fs.readFileSync(authFile))
     };
+    if (argv["skip-test"]) opts.skipTest = true;
     
     var server = ploy(opts);
     if (!argv.q && !argv.quiet) {

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -78,3 +78,8 @@ OPTIONS
   is exactly one ploy remote in set up as a git remote, it will be used by
   default.
 
+  For `ploy server`:
+
+    --skip-test
+      Skip running tests before starting the service.
+

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ function Ploy (opts) {
     
     self.bouncers = [];
     self.auth = opts.auth;
+    self.opts = opts;
     self.restore();
 }
 
@@ -165,7 +166,7 @@ Ploy.prototype.deploy = function (commit) {
     var self = this;
     
     var env = clone(process.env);
-    var procs = spawnProcess(commit, env);
+    var procs = spawnProcess(commit, env, this.opts);
     procs.on('error', function (err) { console.error(err) });
     if (!commit.seq) commit.seq = 0;
     

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -24,7 +24,7 @@ var spawnShell = (function () {
 
 var EventEmitter = require('events').EventEmitter;
 
-module.exports = function (commit, env) {
+module.exports = function (commit, env, opts) {
     var procs = new EventEmitter;
     var hosts = {};
     var streams = {};
@@ -95,7 +95,9 @@ module.exports = function (commit, env) {
             if (pkg.scripts.install) before.push(pkg.scripts.install);
             if (pkg.scripts.postinstall) before.push(pkg.scripts.postinstall);
         }
-        if (pkg.scripts && pkg.scripts.test) before.push(pkg.scripts.test);
+        if (pkg.scripts && pkg.scripts.test && ! opts.skipTest) {
+          before.push(pkg.scripts.test);
+        }
         
         (function next () {
             if (before.length === 0) return runServers(start, stop);

--- a/readme.markdown
+++ b/readme.markdown
@@ -305,6 +305,7 @@ basic auth
 is called for each incoming request with a `bounce()` function from
 [bouncy](https://npmjs.org/package/bouncy). To defer back to ploy, just call
 `bounce()` with no arguments.
+* opts.skipTest - skip running `scripts.test` if true
 
 If `opts` is a string, it will be used as the basedir for `opts.repodir` and
 `opts.workdir`.


### PR DESCRIPTION
I want to skip running tests with ploy. My tests can take a while to run (`npm test` runs integration tests) and when I push to ploy I just want that commit hosted quickly and don't even care if tests are passing or not.

I added an option to skip running tests

Store opts passed to ploy() in this.opts so that it can be later passed to
spawnProcess().

Skip running tests if opts.skipTest is true.

Add command line --skip-test option which will pass `skipTest: true` to
`ploy()` when calling `ploy server`.

Document `--skip-test` and `opts.skipTest` options in readme.